### PR TITLE
PMD ruleset

### DIFF
--- a/src/main/resources/otj-pmd-rulesets/ot-pmd.xml
+++ b/src/main/resources/otj-pmd-rulesets/ot-pmd.xml
@@ -96,9 +96,10 @@
         <exclude name="ExcessiveMethodLength" />
         <!-- sounds good, but a lot of false positives -->
         <exclude name="CouplingBetweenObjects" />
-        <!-- Chris, David have expressed reservations to these two -->
+        <!-- Chris, David have expressed reservations to these 3 -->
         <exclude name="UseObjectForClearerAPI" />
         <exclude name="TooManyFields" />
+        <exclude name="ExcessiveParameterList" />
     </rule>
     <rule ref="category/java/documentation.xml">
         <exclude name="UncommentedEmptyConstructor" />


### PR DESCRIPTION
Note: This requires the new PMD (which itself is not yet merged into parent). The new PMD provides J9 and Java 10 support, but changed the structurign.

Please feel free to make comments. Also if you want to test against your projects for fine tuning

 <dep.pmd.version>6.5.0</dep.pmd.version>
        <dep.plugin.pmd.version>3.10.0</dep.plugin.pmd.version>
        <!-- SNAPSHOTS ARE NOT ACCEPTABLE. BAD MIKE -->
        <dep.plugin.pmd.ruleset.version>1.2.1-SNAPSHOT</dep.plugin.pmd.ruleset.version>

Will do the trick (mvn clean install this branch to get the snapshot)