### PR TITLE
Add another exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 otj-pmd-rulesets changelog
 ==========================
 
+1.2.6
+-----
+* Exclude UnnecessaryFullyQualifiedName
+
+1.2.5
+-----
+* Exclude AvoidUncheckedExceptionsInSignatures
+
 1.2.4
 -----
 * Exclude UseUnderscoresInNumericLiterals

--- a/src/main/resources/otj-pmd-rulesets/ot-pmd.xml
+++ b/src/main/resources/otj-pmd-rulesets/ot-pmd.xml
@@ -79,6 +79,8 @@
         <exclude name="LinguisticNaming" />
         <!-- requires _ in numerics, which is crazy -->
         <exclude name="UseUnderscoresInNumericLiterals" />
+        <!-- Intellij can't handle this rule -->
+        <exclude name="UnnecessaryFullyQualifiedName" />
     </rule>
     <rule ref="category/java/design.xml">
         <exclude name="AvoidDeeplyNestedIfStmts" />


### PR DESCRIPTION
While this one sounds "right", in Intellij it leads to build failures without manually adding a static import. Which is silly.

Example: new Secret.Listener for otj-credentials. It wants you to statically import Secret so there's no qualfication.

Willful, and annoying if technically correct