### PR TITLE
7.0.6 (7.0.4, 7.0.5 were junked while converting to central publishig)

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,2 @@
+[github_app]
+pr_commands = []

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <connection>scm:git:git://github.com/opentable/otj-pmd-rulesets.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pmd-rulesets.git</developerConnection>
     <url>http://github.com/opentable/otj-pmd-rulesets</url>
-    <tag>otj-pmd-rulesets-7.0.4</tag>
+    <tag>HEAD</tag>
   </scm>
   <properties>
     <project.build.targetJdk>11</project.build.targetJdk>
@@ -45,7 +45,7 @@
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>
   <name>otj-pmd-rulesets</name>
-  <version>7.0.4</version>
+  <version>7.0.5-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>OpenTable PMD rulesets</description>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,4 +64,5 @@
   <version>7.0.6-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>OpenTable PMD rulesets</description>
+  <url>https://github.com/opentable/otj-pdm-rulesets</url>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <connection>scm:git:git://github.com/opentable/otj-pmd-rulesets.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pmd-rulesets.git</developerConnection>
     <url>http://github.com/opentable/otj-pmd-rulesets</url>
-    <tag>HEAD</tag>
+    <tag>otj-pmd-rulesets-7.0.4</tag>
   </scm>
   <properties>
     <project.build.targetJdk>11</project.build.targetJdk>
@@ -45,7 +45,7 @@
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>
   <name>otj-pmd-rulesets</name>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <packaging>jar</packaging>
   <description>OpenTable PMD rulesets</description>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.opentable</groupId>
-    <artifactId>otj-parent-spring</artifactId>
-    <version>364</version>
+    <groupId>org.basepom</groupId>
+    <artifactId>basepom-oss</artifactId>
+    <version>63</version>
   </parent>
 
   <scm>
@@ -28,6 +28,19 @@
     <url>http://github.com/opentable/otj-pmd-rulesets</url>
     <tag>HEAD</tag>
   </scm>
+  <properties>
+    <project.build.targetJdk>11</project.build.targetJdk>
+    <maven.compiler.target>${project.build.targetJdk}</maven.compiler.target>
+    <project.build.systemJdk>${project.build.targetJdk}</project.build.systemJdk>
+    <basepom.javadoc.skip>false</basepom.javadoc.skip>
+    <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
+    <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
+    <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
+    <basepom.central-publishing.repo-id>ot-central</basepom.central-publishing.repo-id>
+    <basepom.deploy.snapshot.repo-id>opentable.snapshot</basepom.deploy.snapshot.repo-id>
+    <basepom.deploy.snapshot.url>https://artifactory.otenv.com/snapshots</basepom.deploy.snapshot.url>
+    <basepom.release.profiles>basepom.central-release</basepom.release.profiles>
+  </properties>
 
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>
   <name>otj-pmd-rulesets</name>
-  <version>7.0.3-SNAPSHOT</version>
+  <version>7.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>OpenTable PMD rulesets</description>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,22 @@
     <basepom.release.profiles>basepom.central-release</basepom.release.profiles>
   </properties>
 
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>opentable</id>
+      <name>OpenTable</name>
+      <url>https://github.com/opentable</url>
+    </developer>
+  </developers>
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>
   <name>otj-pmd-rulesets</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <connection>scm:git:git://github.com/opentable/otj-pmd-rulesets.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pmd-rulesets.git</developerConnection>
     <url>http://github.com/opentable/otj-pmd-rulesets</url>
-    <tag>otj-pmd-rulesets-7.0.5</tag>
+    <tag>HEAD</tag>
   </scm>
   <properties>
     <project.build.targetJdk>11</project.build.targetJdk>
@@ -61,7 +61,7 @@
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>
   <name>otj-pmd-rulesets</name>
-  <version>7.0.5</version>
+  <version>7.0.6-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>OpenTable PMD rulesets</description>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <connection>scm:git:git://github.com/opentable/otj-pmd-rulesets.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pmd-rulesets.git</developerConnection>
     <url>http://github.com/opentable/otj-pmd-rulesets</url>
-    <tag>HEAD</tag>
+    <tag>otj-pmd-rulesets-7.0.5</tag>
   </scm>
   <properties>
     <project.build.targetJdk>11</project.build.targetJdk>
@@ -61,7 +61,7 @@
   <groupId>com.opentable</groupId>
   <artifactId>otj-pmd-rulesets</artifactId>
   <name>otj-pmd-rulesets</name>
-  <version>7.0.5-SNAPSHOT</version>
+  <version>7.0.5</version>
   <packaging>jar</packaging>
   <description>OpenTable PMD rulesets</description>
 </project>

--- a/src/main/resources/otj-pmd-rulesets/ot-pmd.xml
+++ b/src/main/resources/otj-pmd-rulesets/ot-pmd.xml
@@ -23,6 +23,8 @@
 
     <description>OpenTable PMD Ruleset</description>
     <rule ref="category/java/bestpractices.xml">
+        <exclude name="ImplicitFunctionalInterface" />
+        <exclude name="ExhaustiveSwitchHasDefault" />
         <exclude name="AccessorMethodGeneration" />
         <exclude name="AvoidReassigningParameters" />
         <exclude name="UseVarargs" />


### PR DESCRIPTION

- Excluded two PMD rules: ImplicitFunctionalInterface and ExhaustiveSwitchHasDefault

- Updated project version to 7.0.4-SNAPSHOT in pom.xml
